### PR TITLE
ci: CIワークフローにMarkdown Lintジョブを追加

### DIFF
--- a/.claude/rules/04-test-rules.md
+++ b/.claude/rules/04-test-rules.md
@@ -20,6 +20,7 @@
 
 - 外部依存（Supabase、APIなど）は jest.mock でモック化
 - モック関数は describe ブロックの外で定義
+
   ```typescript
   const mockGetUser = jest.fn();
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,19 @@ on:
       - main
 
 jobs:
-  ci:
+  markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: '**/*.md'
+
+  frontend:
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,3 @@
+{
+  "ignores": ["node_modules/**"]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: lint-md
+
+lint-md:
+	npx markdownlint-cli2 "**/*.md"


### PR DESCRIPTION
## Summary
- CIワークフローにMarkdown Lintジョブを追加
- markdownlint-cli2-actionを使用してMarkdownファイルのLintを実行
- 既存の`ci`ジョブを`frontend`にリネームして役割を明確化

## Test plan
- [ ] CIワークフローが正常に実行されることを確認
- [ ] Markdown Lintジョブが正常に動作することを確認
- [ ] frontendジョブが既存の動作を維持していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)