### PR TITLE
refactor: 環境変数名をSupabase公式命名規則に変更

### DIFF
--- a/.claude/rules/02-supabase.md
+++ b/.claude/rules/02-supabase.md
@@ -2,8 +2,8 @@
 
 ## キー
 
-- NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY：認証のみ。DBへの接続には使用しない。
-- SUPABASE_SECRET_KEY：DB操作（接続、参照、追加、更新、削除）のみ。
+- NEXT_PUBLIC_SUPABASE_ANON_KEY：認証のみ。DBへの接続には使用しない。
+- SUPABASE_SERVICE_ROLE_KEY：DB操作（接続、参照、追加、更新、削除）のみ。
 
 ## 認証クライアント
 

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
-SUPABASE_SECRET_KEY=your_supabase_secret_key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Next.js + Supabase Authで認証機能を実装するサンプルです。
 
 ### キーの使い方
 
-`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` は全てのデータベースの操作権限を剥奪し認証のみで利用
-`SUPABASE_SECRET_KEY` を使いAPI経由でデータベースの参照、更新を行う
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` は全てのデータベースの操作権限を剥奪し認証のみで利用
+`SUPABASE_SERVICE_ROLE_KEY` を使いAPI経由でデータベースの参照、更新を行う
 
 ### Migrationについて
 
@@ -36,12 +36,12 @@ supabase start
 
 `.env.local`を作成し、以下の環境変数を設定します。
 
-Supabaseの起動で表示されたURLとPUBLISHABLEキー、サービスロールキーを設定してください。
+Supabaseの起動で表示されたURLとANONキー、サービスロールキーを設定してください。
 
 ```plaintext
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54322
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
-SUPABASE_SECRET_KEY=your_supabase_secret_key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 ```
 
 ### サーバー起動

--- a/amplify.yml
+++ b/amplify.yml
@@ -8,8 +8,8 @@ frontend:
     build:
       commands:
         - echo "NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL" >> .env
-        - echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" >> .env
-        - echo "SUPABASE_SECRET_KEY=$SUPABASE_SECRET_KEY" >> .env
+        - echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY" >> .env
+        - echo "SUPABASE_SERVICE_ROLE_KEY=$SUPABASE_SERVICE_ROLE_KEY" >> .env
         - npm run type-check
         - npm run build
   artifacts:

--- a/src/__test__/test-client.ts
+++ b/src/__test__/test-client.ts
@@ -4,8 +4,8 @@ import { config } from "dotenv";
 config({ path: ".env.local" });
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "";
-const supabaseSecretKey = process.env.SUPABASE_SECRET_KEY ?? "";
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+const supabaseSecretKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 
 export function createAnonClient() {
   return createClient(supabaseUrl, supabaseAnonKey);

--- a/src/infrastructure/database/supabase/client.ts
+++ b/src/infrastructure/database/supabase/client.ts
@@ -2,7 +2,7 @@ import { createBrowserClient } from "@supabase/ssr";
 
 export function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !anonKey) {
     throw new Error("Missing Supabase environment variables");

--- a/src/infrastructure/database/supabase/middleware.ts
+++ b/src/infrastructure/database/supabase/middleware.ts
@@ -7,7 +7,7 @@ export async function updateSession(request: NextRequest) {
   });
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !publishableKey) {
     throw new Error("Missing Supabase environment variables");

--- a/src/infrastructure/database/supabase/server.ts
+++ b/src/infrastructure/database/supabase/server.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 export async function createClient() {
   const cookieStore = await cookies();
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceSecretKey = process.env.SUPABASE_SECRET_KEY;
+  const serviceSecretKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url || !serviceSecretKey) {
     throw new Error("Missing Supabase environment variables");


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` → `NEXT_PUBLIC_SUPABASE_ANON_KEY` に変更
- `SUPABASE_SECRET_KEY` → `SUPABASE_SERVICE_ROLE_KEY` に変更
- Supabase公式ドキュメントの命名規則に準拠

## Test plan
- [ ] 環境変数を新しい名前で設定し、アプリケーションが正常に起動することを確認
- [ ] 認証機能が正常に動作することを確認
- [ ] API経由でのデータベース操作が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)